### PR TITLE
Remove proxy models from the list of reportable models

### DIFF
--- a/anonymiser/management/commands/anonymisation_config.py
+++ b/anonymiser/management/commands/anonymisation_config.py
@@ -25,7 +25,7 @@ def get_model_anonymisers() -> list[ModelAnonymiserSummary]:
     """
     output = []
     for m in apps.get_models():
-        if m._meta.abstract:
+        if m._meta.abstract or m._meta.proxy:
             continue
         if anonymiser := registry.get_model_anonymiser(m):
             output.append(

--- a/tests/models.py
+++ b/tests/models.py
@@ -16,7 +16,10 @@ class ProxyUser(User):
     """
     A proxy model for testing the anonymiser.
 
-    Proxy models should not be included in the anonymisation config.
+    Proxy models should not be included in the anonymisation config;
+    and thus the presence of this model alone is way of ensuring that
+    it does not appear during testing.
+
     """
 
     class Meta:

--- a/tests/models.py
+++ b/tests/models.py
@@ -10,3 +10,14 @@ class User(AbstractUser):
     biography = models.TextField(blank=True)
     date_of_birth = models.DateField(blank=True, null=True)
     extra_info = models.JSONField(default=dict)
+
+
+class ProxyUser(User):
+    """
+    A proxy model for testing the anonymiser.
+
+    Proxy models should not be included in the anonymisation config.
+    """
+
+    class Meta:
+        proxy = True


### PR DESCRIPTION
Proxy models are not "real" tables, they are essentially views into an existing one.

So, like abstract models, they should not be included in the snapshot generation.

This fix ensures that is the case. A proxy model is added to the test model suite to ensure that it does not show up in the existing test suite.