### PR TITLE
Misc: Django 5.2 upgrade

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -38,11 +38,26 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.11", "3.12"]
-        django: ["42", "50", "main"]
+        include:
+          # Django 4.2
+          - python: "3.11"
+            django: "42"
+          # Django 5.0
+          - python: "3.11"
+            django: "50"
+          - python: "3.12"
+            django: "50"
+          # Django 5.2
+          - python: "3.11"
+            django: "52"
+          - python: "3.12"
+            django: "52"
+          # Django main
+          - python: "3.12"
+            django: "main"
 
     env:
-      TOXENV: py${{ matrix.python }}-django${{ matrix.django }}
+      TOXENV: django${{ matrix.django }}-py${{ matrix.python }}
 
     steps:
       - name: Check out the repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,13 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.0.262"
+    rev: "v0.3.0"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Django app for managing / tracking Django model anonymisation.
 This is currently used internally only, and has not been published to
 PyPI - use with caution.
 
+## Compatibility
+
+- Python: 3.11+
+- Django: 4.2, 5.0, 5.2
+
 ## Background
 We currently have a pattern of each model having its own `anonymise`
 method, and a management command that iterates over each model calling

--- a/anonymiser/management/commands/anonymisation_config.py
+++ b/anonymiser/management/commands/anonymisation_config.py
@@ -47,9 +47,7 @@ class Command(BaseCommand):
             "-t",
             "--template",
             default="anonymisation_config.md",
-            help=(
-                "Template to use for output (defaults to " "anonymisation_config.md)."
-            ),
+            help=("Template to use for output (defaults to anonymisation_config.md)."),
         )
 
     def handle(self, *args: Any, **options: Any) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-anonymise"
-version = "0.2.0"
+version = "0.3.0"
 description = "Django app used to manage production data anonymisation."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -14,6 +14,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
@@ -24,7 +25,7 @@ packages = [{ include = "anonymiser" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-django = "^3.2 || ^4.0 || ^5.0"
+django = "^4.2 || ^5.0 || ^5.2"
 # optional - used for testing with Postgres
 psycopg2-binary = { version = "*", optional = true }
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ envlist =
     ; https://docs.djangoproject.com/en/5.0/releases/
     django42-py{311}
     django50-py{311,312}
-    djangomain-py{311,312}
+    django52-py{311,312}
+    djangomain-py{312}
 
 [testenv]
 deps =
@@ -17,7 +18,8 @@ deps =
     pytest-cov
     pytest-django
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django52: https://github.com/django/django/archive/stable/5.2.x.tar.gz
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
# Django 5.2 Compatibility Update

This PR updates the project to support Django 5.2 while deprecating support for Django versions before 4.2.

## Changes

- **Version Bump**: Increased version from 0.2.0 to 0.3.0
- **Django Compatibility**:
  - Added support for Django 5.2
  - Removed support for Django versions before 4.2
  - Updated classifiers in pyproject.toml
- **Testing Infrastructure**:
  - Added Django 5.2 test environments in tox.ini
  - Limited Django main branch testing to Python 3.12 only
  - Updated GitHub Actions workflow to match the new test matrix
- **Developer Tools**:
  - Updated ruff to v0.3.0
  - Updated pre-commit configuration to use modern ruff hooks
  - Added ruff-format hook for more consistent formatting
- **Documentation**:
  - Added compatibility section to `README` with supported versions