### PR TITLE
Logging configuration updates

### DIFF
--- a/anonymiser/models.py
+++ b/anonymiser/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import logging
 from enum import StrEnum  # 3.11 only
 from typing import Any, Callable, TypeAlias
 
@@ -11,8 +10,6 @@ from .redacters import get_default_field_redacter
 
 # (old_value, new_value) tuple
 AnonymisationResult: TypeAlias = tuple[Any, Any]
-
-logger = logging.getLogger(__name__)
 
 
 def get_model_fields(model: type[models.Model]) -> list[models.Field]:

--- a/anonymiser/registry.py
+++ b/anonymiser/registry.py
@@ -30,7 +30,7 @@ class Registry(dict):
                 raise ValueError("Anonymiser must have a model attribute set.")
             if model in self:
                 raise ValueError(f"Anonymiser for {model} already registered")
-            logging.debug("Adding anonymiser for %s to registry", model._meta.label)
+            logger.debug("Adding anonymiser for %s to registry", model._meta.label)
             self[model] = anonymiser
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-anonymise"
-version = "0.4.0"
+version = "0.4.1"
 description = "Django app used to manage production data anonymisation."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove unused logger from `models.py` and route `registry.py` debug logs through its module logger for better filtering.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
- Removing `logger` from `anonymiser/models.py` just because it's unused. 
- `anonymiser/registry.py` already had a module logger but was still using `logging.debug`, which routes messages through the root logger. Changing this to `logger.debug` allows consumers to filter these specific messages using standard Django/Python logging configuration (e.g., `anonymiser.registry`). 
---
<a href="https://cursor.com/background-agent?bcId=bc-4dfd2c56-2a10-49ad-af66-68670f019bad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4dfd2c56-2a10-49ad-af66-68670f019bad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves logging scoping and bumps package version.
> 
> - Route `anonymiser/registry.py` debug output through module logger by replacing `logging.debug` with `logger.debug`
> - Remove unused logger from `anonymiser/models.py`
> - Bump package version in `pyproject.toml` to `0.4.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c5480afd1596821dded206cef5954b13abfcb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->