### PR TITLE
Add Django 6.0 and Python 3.13 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install and run tox
         run: |
@@ -38,23 +38,8 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          # Django 4.2
-          - python: "3.11"
-            django: "42"
-          # Django 5.0
-          - python: "3.11"
-            django: "50"
-          - python: "3.12"
-            django: "50"
-          # Django 5.2
-          - python: "3.11"
-            django: "52"
-          - python: "3.12"
-            django: "52"
-          # Django main
-          - python: "3.12"
-            django: "main"
+        python: ["3.12", "3.13"]
+        django: ["52", "60", "main"]
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ PyPI - use with caution.
 
 ## Compatibility
 
-- Python: 3.11+
-- Django: 4.2, 5.0, 5.2
+- Python: 3.12+
+- Django: 5.2, 6.0
 
 ## Background
 We currently have a pattern of each model having its own `anonymise`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-anonymise"
-version = "0.4.0"
+version = "0.5.0"
 description = "Django app used to manage production data anonymisation."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -12,20 +12,19 @@ documentation = "https://github.com/yunojuno/django-anonymiser"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "anonymiser" }]
 
 [tool.poetry.dependencies]
-python = "^3.11"
-django = "^4.2 || ^5.0 || ^5.2"
+python = "^3.12"
+django = ">=5.2,<7.0"
 # optional - used for testing with Postgres
 psycopg2-binary = { version = "*", optional = true }
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,9 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.0/releases/
-    django42-py{311}
-    django50-py{311,312}
-    django52-py{311,312}
-    djangomain-py{312}
+    django52-py{312,313}
+    django60-py{312,313}
+    djangomain-py{312,313}
 
 [testenv]
 deps =
@@ -17,9 +15,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
-    django52: https://github.com/django/django/archive/stable/5.2.x.tar.gz
+    django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
## Summary

This PR upgrades the package to support Django 6.0 and Python 3.13.

## Changes

### Added
  - ✅ Django 6.0 support
  - ✅ Python 3.12, 3.13 support

### Removed
  - ❌ Python 3.9, 3.10, 3.11 support (now requires Python 3.12+)
  - ❌ Django 4.2 and 5.0 support (now supports Django 5.2-6.0)